### PR TITLE
fix: close writer and notify relay on target EOF in edge agent

### DIFF
--- a/http_network_relay/edge_agent.py
+++ b/http_network_relay/edge_agent.py
@@ -249,18 +249,37 @@ class EdgeAgent:
 
         # start async coroutine to read from the TCP connection and send it to the server
         async def read_from_tcp_and_send():
-            while True:
-                data = await reader.read(1024)
-                if not data:
-                    break
-                await server_websocket.send(
-                    EdgeAgentToRelayMessage(
-                        inner=EtRTCPDataMessage(
-                            connection_id=message.connection_id,
-                            data_base64=base64.b64encode(data).decode("utf-8"),
-                        )
-                    ).model_dump_json()
-                )
+            try:
+                while True:
+                    data = await reader.read(1024)
+                    if not data:
+                        break
+                    await server_websocket.send(
+                        EdgeAgentToRelayMessage(
+                            inner=EtRTCPDataMessage(
+                                connection_id=message.connection_id,
+                                data_base64=base64.b64encode(data).decode("utf-8"),
+                            )
+                        ).model_dump_json()
+                    )
+            finally:
+                # Close the writer and remove from active_connections regardless of
+                # how the loop exits (EOF, exception, or relay-initiated close).
+                # Without this, every SSH session that ends naturally leaks one fd
+                # until the process hits its fd limit.
+                writer.close()
+                self.active_connections.pop(message.connection_id, None)
+                try:
+                    await server_websocket.send(
+                        EdgeAgentToRelayMessage(
+                            inner=EtRConnectionResetMessage(
+                                message="Connection closed by target",
+                                connection_id=message.connection_id,
+                            )
+                        ).model_dump_json()
+                    )
+                except Exception:
+                    pass  # websocket may already be closed
 
         asyncio.create_task(read_from_tcp_and_send())
 


### PR DESCRIPTION
## Problem

`read_from_tcp_and_send()` exited on empty read (remote EOF) without closing the `asyncio.StreamWriter` or removing the entry from `active_connections`. Every SSH/VNC session that ends naturally leaked one file descriptor.

On the default systemd soft limit of 1024 fds the agent exhausts its budget; `asyncio.open_connection()` then fails with `[Errno 16] Device or resource busy` (Python 3.13 happy-eyeballs translates `EMFILE` as `EBUSY`). The agent stops proxying all connections until restarted.

Observed in production on a HomePi4 running thymis-agent continuously — terminal/SSH relay broke after accumulated sessions hit the fd ceiling.

## Fix

Wrap the read loop in `try/finally` that:
- calls `writer.close()` to release the fd
- pops from `active_connections` so stale entries don't accumulate
- sends `EtRConnectionResetMessage` to notify the relay the target closed its side (guarded against a closed websocket)