### PR TITLE
feat: binary websocket framing + performance optimisations

### DIFF
--- a/http_network_relay/access_client.py
+++ b/http_network_relay/access_client.py
@@ -103,16 +103,17 @@ class AccessClient:
             start_response = RelayToAccessClientMessage.model_validate_json(
                 start_response_json
             )
-            eprint(f"Received start response: {start_response}")
             relay_supports_binary = False
             if isinstance(start_response.inner, RtAStartOKMessage):
                 relay_supports_binary = getattr(
                     start_response.inner, "supports_binary", False
                 )
                 eprint(f"Received OK message: {start_response}")
-                eprint(f"Relay supports binary: {relay_supports_binary}")
             elif isinstance(start_response.inner, RtAErrorMessage):
                 eprint(f"Received error message: {start_response}")
+                return
+            else:
+                eprint(f"Received unknown message: {start_response}")
                 return
 
             # start async coroutine to read stdin and send it to the server

--- a/http_network_relay/access_client.py
+++ b/http_network_relay/access_client.py
@@ -83,7 +83,8 @@ class AccessClient:
             raise ValueError("relay_url is required")
         if self.secret is None:
             raise ValueError("secret is required")
-        async with connect(self.relay_url) as websocket:
+        # disable compression, the data is usually already compressed
+        async with connect(self.relay_url, compression=None) as websocket:
             start_message = AccessClientToRelayMessage(
                 inner=AtRStartMessage(
                     connection_target=self.target_host_identifier,

--- a/http_network_relay/access_client.py
+++ b/http_network_relay/access_client.py
@@ -8,6 +8,8 @@ import websockets
 from pydantic import BaseModel, Field
 from websockets.asyncio.client import connect
 
+from .pydantic_models import READ_CHUNK_SIZE
+
 
 class AccessClientToRelayMessage(BaseModel):
     inner: Union["AtRStartMessage", "AtRTCPDataMessage"] = Field(discriminator="kind")
@@ -20,6 +22,7 @@ class AtRStartMessage(BaseModel):
     target_port: int
     protocol: str
     secret: str
+    supports_binary: bool | None = False
 
 
 class AtRTCPDataMessage(BaseModel):
@@ -40,6 +43,7 @@ class RtAErrorMessage(BaseModel):
 
 class RtAStartOKMessage(BaseModel):
     kind: Literal["start_ok"] = "start_ok"
+    supports_binary: bool | None = False
 
 
 class RtATCPDataMessage(BaseModel):
@@ -87,6 +91,7 @@ class AccessClient:
                     target_port=self.target_port,
                     protocol=self.protocol,
                     secret=self.secret,
+                    supports_binary=True,
                 )
             )
             await websocket.send(start_message.model_dump_json())
@@ -96,8 +101,13 @@ class AccessClient:
                 start_response_json
             )
             eprint(f"Received start response: {start_response}")
+            relay_supports_binary = False
             if isinstance(start_response.inner, RtAStartOKMessage):
+                relay_supports_binary = getattr(
+                    start_response.inner, "supports_binary", False
+                )
                 eprint(f"Received OK message: {start_response}")
+                eprint(f"Relay supports binary: {relay_supports_binary}")
             elif isinstance(start_response.inner, RtAErrorMessage):
                 eprint(f"Received error message: {start_response}")
                 return
@@ -109,16 +119,19 @@ class AccessClient:
                 reader_protocol = asyncio.StreamReaderProtocol(reader)
                 await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
                 while True:
-                    data = await reader.read(1024)
+                    data = await reader.read(READ_CHUNK_SIZE)
                     if not data:
                         break
-                    await websocket.send(
-                        AccessClientToRelayMessage(
-                            inner=AtRTCPDataMessage(
-                                data_base64=base64.b64encode(data).decode("utf-8")
-                            )
-                        ).model_dump_json()
-                    )
+                    if relay_supports_binary:
+                        await websocket.send(data)
+                    else:
+                        await websocket.send(
+                            AccessClientToRelayMessage(
+                                inner=AtRTCPDataMessage(
+                                    data_base64=base64.b64encode(data).decode("utf-8")
+                                )
+                            ).model_dump_json()
+                        )
 
             read_stdin_and_send_task = asyncio.create_task(read_stdin_and_send())
 
@@ -131,6 +144,10 @@ class AccessClient:
                 except websockets.exceptions.ConnectionClosedOK as e:
                     eprint(f"Connection closed: OK: {e}")
                     break
+                if isinstance(json_data, (bytes, bytearray)):
+                    sys.stdout.buffer.write(json_data)
+                    sys.stdout.flush()
+                    continue
                 message = RelayToAccessClientMessage.model_validate_json(json_data)
                 eprint(f"Received message: {message}", only_debug=True)
                 if isinstance(message.inner, RtATCPDataMessage):

--- a/http_network_relay/access_client.py
+++ b/http_network_relay/access_client.py
@@ -84,7 +84,9 @@ class AccessClient:
         if self.secret is None:
             raise ValueError("secret is required")
         # disable compression, the data is usually already compressed
-        async with connect(self.relay_url, compression=None) as websocket:
+        async with connect(
+            self.relay_url, max_size=2**32, compression=None
+        ) as websocket:
             start_message = AccessClientToRelayMessage(
                 inner=AtRStartMessage(
                     connection_target=self.target_host_identifier,
@@ -116,7 +118,7 @@ class AccessClient:
             # start async coroutine to read stdin and send it to the server
             async def read_stdin_and_send():
                 loop = asyncio.get_event_loop()
-                reader = asyncio.StreamReader()
+                reader = asyncio.StreamReader(limit=READ_CHUNK_SIZE)
                 reader_protocol = asyncio.StreamReaderProtocol(reader)
                 await loop.connect_read_pipe(lambda: reader_protocol, sys.stdin)
                 while True:

--- a/http_network_relay/edge_agent.py
+++ b/http_network_relay/edge_agent.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ValidationError
 from websockets.asyncio.client import ClientConnection, connect
 
 from .pydantic_models import (
+    READ_CHUNK_SIZE,
     EdgeAgentToRelayMessage,
     EtRConnectionResetMessage,
     EtRInitiateConnectionErrorMessage,
@@ -22,6 +23,8 @@ from .pydantic_models import (
     RtEInitiateConnectionMessage,
     RtEKeepAliveMessage,
     RtETCPDataMessage,
+    decode_tcp_binary_frame,
+    encode_tcp_binary_frame,
 )
 
 debug = False
@@ -86,12 +89,12 @@ class EdgeAgent:
 
     async def connect_to_server(self, last_error):
         async with connect(self.relay_url, max_size=2**32) as websocket:
-            start_message = EdgeAgentToRelayMessage(
-                inner=EtRStartMessage.model_validate(
-                    (await self.create_start_message(last_error)).model_dump(),
-                    from_attributes=True,
-                )
+            inner_start = EtRStartMessage.model_validate(
+                (await self.create_start_message(last_error)).model_dump(),
+                from_attributes=True,
             )
+            inner_start.supports_binary = True
+            start_message = EdgeAgentToRelayMessage(inner=inner_start)
             await websocket.send(start_message.model_dump_json())
             eprint(f"Sent start message: {start_message}")
             self.websocket = websocket
@@ -124,6 +127,11 @@ class EdgeAgent:
                 except websockets.exceptions.ConnectionClosedOK as e:
                     eprint(f"Connection closed OK: {e}")
                     break
+                if isinstance(json_data, (bytes, bytearray)):
+                    # Hot path: raw TCP payload framed as connection_id + bytes.
+                    conn_id, payload = decode_tcp_binary_frame(json_data)
+                    await self.write_to_connection(conn_id, payload, websocket)
+                    continue
                 try:
                     message = RelayToEdgeAgentMessage.model_validate_json(
                         json_data
@@ -156,38 +164,11 @@ class EdgeAgent:
                             ).model_dump_json()
                         )
                 elif isinstance(message, RtETCPDataMessage):
-                    tcp_data_message = message
-                    eprint(
-                        f"Received TCP data message: {tcp_data_message}",
-                        only_debug=True,
+                    await self.write_to_connection(
+                        message.connection_id,
+                        base64.b64decode(message.data_base64),
+                        websocket,
                     )
-                    # associate the connection_id with the websocket
-                    if tcp_data_message.connection_id not in self.active_connections:
-                        eprint(
-                            f"Unknown connection_id: {tcp_data_message.connection_id}"
-                        )
-                        continue
-                    reader, writer = self.active_connections[
-                        tcp_data_message.connection_id
-                    ]
-                    writer.write(base64.b64decode(tcp_data_message.data_base64))
-                    try:
-                        await writer.drain()
-                    except ConnectionResetError:
-                        eprint("Connection reset while writing data")
-                        eprint(
-                            f"Closing active connection: {tcp_data_message.connection_id}, due to connection reset"
-                        )
-                        writer.close()
-                        del self.active_connections[tcp_data_message.connection_id]
-                        await websocket.send(
-                            EdgeAgentToRelayMessage(
-                                inner=EtRConnectionResetMessage(
-                                    message="Connection reset while writing data",
-                                    connection_id=tcp_data_message.connection_id,
-                                )
-                            ).model_dump_json()
-                        )
                 elif isinstance(message, RtEConnectionCloseMessage):
                     connection_close_message = message
                     eprint(
@@ -224,6 +205,30 @@ class EdgeAgent:
                 else:
                     eprint(f"Unknown message received: {message}")
 
+    async def write_to_connection(self, connection_id, data, server_websocket):
+        if connection_id not in self.active_connections:
+            eprint(f"Unknown connection_id: {connection_id}")
+            return
+        writer = self.active_connections[connection_id][1]
+        writer.write(data)
+        try:
+            await writer.drain()
+        except ConnectionResetError:
+            eprint("Connection reset while writing data")
+            eprint(
+                f"Closing active connection: {connection_id}, due to connection reset"
+            )
+            writer.close()
+            del self.active_connections[connection_id]
+            await server_websocket.send(
+                EdgeAgentToRelayMessage(
+                    inner=EtRConnectionResetMessage(
+                        message="Connection reset while writing data",
+                        connection_id=connection_id,
+                    )
+                ).model_dump_json()
+            )
+
     async def initiate_connection(
         self, message: RtEInitiateConnectionMessage, server_websocket: ClientConnection
     ):
@@ -251,17 +256,22 @@ class EdgeAgent:
         async def read_from_tcp_and_send():
             try:
                 while True:
-                    data = await reader.read(1024)
+                    data = await reader.read(READ_CHUNK_SIZE)
                     if not data:
                         break
-                    await server_websocket.send(
-                        EdgeAgentToRelayMessage(
-                            inner=EtRTCPDataMessage(
-                                connection_id=message.connection_id,
-                                data_base64=base64.b64encode(data).decode("utf-8"),
-                            )
-                        ).model_dump_json()
-                    )
+                    if message.supports_binary:
+                        await server_websocket.send(
+                            encode_tcp_binary_frame(message.connection_id, data)
+                        )
+                    else:
+                        await server_websocket.send(
+                            EdgeAgentToRelayMessage(
+                                inner=EtRTCPDataMessage(
+                                    connection_id=message.connection_id,
+                                    data_base64=base64.b64encode(data).decode("utf-8"),
+                                )
+                            ).model_dump_json()
+                        )
             finally:
                 # Close the writer and remove from active_connections regardless of
                 # how the loop exits (EOF, exception, or relay-initiated close).

--- a/http_network_relay/edge_agent.py
+++ b/http_network_relay/edge_agent.py
@@ -242,7 +242,7 @@ class EdgeAgent:
             eprint(f"Unsupported protocol: {message.protocol}")
             raise NotImplementedError(f"Unsupported protocol: {message.protocol}")
         reader, writer = await asyncio.open_connection(
-            message.target_ip, message.target_port
+            message.target_ip, message.target_port, limit=READ_CHUNK_SIZE
         )
         self.active_connections[message.connection_id] = (reader, writer)
         eprint(f"Connected to {message.target_ip}:{message.target_port}")

--- a/http_network_relay/edge_agent.py
+++ b/http_network_relay/edge_agent.py
@@ -88,7 +88,10 @@ class EdgeAgent:
             last_connection_attempt_time = time.time()
 
     async def connect_to_server(self, last_error):
-        async with connect(self.relay_url, max_size=2**32) as websocket:
+        # disable compression, the data is usually already compressed
+        async with connect(
+            self.relay_url, max_size=2**32, compression=None
+        ) as websocket:
             inner_start = EtRStartMessage.model_validate(
                 (await self.create_start_message(last_error)).model_dump(),
                 from_attributes=True,

--- a/http_network_relay/network_relay.py
+++ b/http_network_relay/network_relay.py
@@ -21,6 +21,7 @@ from .access_client import (
     RtATCPDataMessage,
 )
 from .pydantic_models import (
+    READ_CHUNK_SIZE,
     EdgeAgentToRelayMessage,
     EtRConnectionResetMessage,
     EtRInitiateConnectionErrorMessage,
@@ -34,6 +35,8 @@ from .pydantic_models import (
     RtEInitiateConnectionMessage,
     RtEKeepAliveMessage,
     RtETCPDataMessage,
+    decode_tcp_binary_frame,
+    encode_tcp_binary_frame,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,6 +50,7 @@ class TcpConnection(AbstractContextManager):
         relay: "NetworkRelay",
         agent_connection: WebSocket,
         loop,
+        agent_supports_binary: bool = False,
     ):
         self.id = connection_id
         self.relay = relay
@@ -58,6 +62,7 @@ class TcpConnection(AbstractContextManager):
         self.send_buffer = bytearray()
         self.send_buffer_lock = threading.Lock()
         self.loop = loop
+        self.agent_supports_binary = agent_supports_binary
 
     def send(self, content):
         with self.send_buffer_lock:
@@ -71,13 +76,18 @@ class TcpConnection(AbstractContextManager):
         with self.send_buffer_lock:
             content = self.send_buffer
             self.send_buffer = bytearray()
-            await self.relay.send_connection_message(
-                self.agent_connection,
-                RtETCPDataMessage(
-                    connection_id=self.id,
-                    data_base64=base64.b64encode(content).decode(),
-                ),
-            )
+            if self.agent_supports_binary:
+                await self.relay.send_connection_binary(
+                    self.agent_connection, self.id, content
+                )
+            else:
+                await self.relay.send_connection_message(
+                    self.agent_connection,
+                    RtETCPDataMessage(
+                        connection_id=self.id,
+                        data_base64=base64.b64encode(content).decode(),
+                    ),
+                )
 
     def fill_recv(self, data: bytes):
         with self.recv_buffer_lock:
@@ -138,6 +148,7 @@ class TcpConnectionAsync(AbstractAsyncContextManager):
         relay: "NetworkRelay",
         agent_connection: WebSocket,
         loop,
+        agent_supports_binary: bool = False,
     ):
         self.id = connection_id
         self.relay = relay
@@ -146,8 +157,13 @@ class TcpConnectionAsync(AbstractAsyncContextManager):
         self.timeout = None
         self.event = asyncio.Event()
         self.loop = loop
+        self.agent_supports_binary = agent_supports_binary
 
     async def send(self, content):
+        if self.agent_supports_binary:
+            return await self.relay.send_connection_binary(
+                self.agent_connection, self.id, content
+            )
         return await self.relay.send_connection_message(
             self.agent_connection,
             RtETCPDataMessage(
@@ -216,6 +232,8 @@ class NetworkRelay:
         self.active_access_client_connections: dict[
             str, WebSocket
         ] = {}  # connection_id -> WebSocket for access clients
+        # agent_connection_id -> whether that agent negotiated binary framing
+        self.agent_connection_id_to_supports_binary: dict[str, bool] = {}
         self.loop: Optional[asyncio.AbstractEventLoop] = None
 
     async def accept_ws_and_start_msg_loop_for_edge_agents(
@@ -228,6 +246,7 @@ class NetworkRelay:
         start_message = EdgeAgentToRelayMessage.model_validate_json(
             start_message_json_data
         ).inner
+        agent_supports_binary = getattr(start_message, "supports_binary", False)
         logger.info("Message received from agent: %s", start_message)
         if not isinstance(start_message, EtRStartMessage):
             logger.warning("Unknown message received from agent: %s", start_message)
@@ -249,6 +268,9 @@ class NetworkRelay:
             await edge_agent_connection.close()
             return
         connection_id = connection_id_or_falsy
+        self.agent_connection_id_to_supports_binary[
+            connection_id
+        ] = agent_supports_binary
 
         # check if the agent is already registered
         if connection_id in self.registered_agent_connections:
@@ -308,12 +330,23 @@ class NetworkRelay:
     async def _msg_loop(self, edge_agent_connection: WebSocket, connection_id: str):
         while True:
             try:
-                json_data = await edge_agent_connection.receive_text()
-                logger.debug("Received message from agent: %s", json_data)
+                raw = await edge_agent_connection.receive()
             except WebSocketDisconnect:
                 logger.warning("Agent disconnected: %s", connection_id)
                 await self.edge_agent_connection_close(connection_id)
                 break
+            if raw["type"] == "websocket.disconnect":
+                logger.warning("Agent disconnected: %s", connection_id)
+                await self.edge_agent_connection_close(connection_id)
+                break
+            binary = raw.get("bytes")
+            if binary is not None:
+                # Hot path: raw TCP payload framed as connection_id + bytes.
+                conn_id, payload = decode_tcp_binary_frame(binary)
+                await self.handle_tcp_binary_data(conn_id, payload)
+                continue
+            json_data = raw["text"]
+            logger.debug("Received message from agent: %s", json_data)
             message_outer = None
             try:
                 message_outer = EdgeAgentToRelayMessage.model_validate_json(json_data)
@@ -392,8 +425,15 @@ class NetworkRelay:
             raise ValueError(f"Unknown agent: {agent_connection_id}")
         # step 0. create TcpConnection object so that messages sent immediately after tcp creation can be received by the main loop
         connection_id = str(uuid.uuid4())
+        agent_supports_binary = self.agent_connection_id_to_supports_binary.get(
+            agent_connection_id, False
+        )
         connection = connection_class(
-            connection_id, self, agent_connection, asyncio.get_event_loop()
+            connection_id,
+            self,
+            agent_connection,
+            asyncio.get_event_loop(),
+            agent_supports_binary=agent_supports_binary,
         )
         self.active_relayed_connections[connection_id] = connection
         # step 1. send initiate connection message to agent
@@ -404,6 +444,7 @@ class NetworkRelay:
                 target_port=target_port,
                 protocol=protocol,
                 connection_id=str(connection_id),
+                supports_binary=True,
             ),
         )
         match response:
@@ -442,6 +483,15 @@ class NetworkRelay:
         connection = self.active_relayed_connections[message.connection_id]
         connection.fill_recv(base64.b64decode(message.data_base64))
 
+    async def handle_tcp_binary_data(self, connection_id: str, payload: bytes):
+        connection = self.active_relayed_connections.get(connection_id)
+        if connection is None:
+            logger.warning(
+                "Unknown connection_id for binary TCP data: %s", connection_id
+            )
+            return
+        connection.fill_recv(payload)
+
     async def handle_connection_reset_message(self, message: EtRConnectionResetMessage):
         if message.connection_id not in self.active_relayed_connections:
             logger.warning(
@@ -476,6 +526,13 @@ class NetworkRelay:
     ):
         await agent_connection.send_text(
             RelayToEdgeAgentMessage(inner=message).model_dump_json()
+        )
+
+    async def send_connection_binary(
+        self, agent_connection: WebSocket, connection_id: str, payload: bytes
+    ):
+        await agent_connection.send_bytes(
+            encode_tcp_binary_frame(connection_id, payload)
         )
 
     def is_closed_error(self, error: RuntimeError):
@@ -539,6 +596,7 @@ class NetworkRelay:
             logger.warning("Unknown message received from access client: %s", message)
             return
         start_message = message.inner
+        access_client_supports_binary = getattr(start_message, "supports_binary", False)
         # check if credentials are correct
         if not await self.get_access_client_permission(
             start_message, access_client_connection
@@ -574,7 +632,9 @@ class NetworkRelay:
             )
             await access_client_connection.send_text(
                 RelayToAccessClientMessage(
-                    inner=RtAStartOKMessage(connection_id=connection.id)
+                    inner=RtAStartOKMessage(
+                        connection_id=connection.id, supports_binary=True
+                    )
                 ).model_dump_json()
             )
         except ValueError as e:
@@ -595,17 +655,30 @@ class NetworkRelay:
         logger.info("access client connection created: %s", connection)
         self.active_access_client_connections[connection.id] = access_client_connection
         reader = asyncio.create_task(
-            self.access_client_receive_thread(access_client_connection, connection)
+            self.access_client_receive_thread(
+                access_client_connection, connection, access_client_supports_binary
+            )
         )
         while connection.id in self.active_access_client_connections:
             try:
-                json_data = await access_client_connection.receive_text()
+                raw = await access_client_connection.receive()
             except WebSocketDisconnect:
                 logger.info("access client disconnected: %s", connection.id)
                 if connection.id in self.active_relayed_connections:
                     del self.active_relayed_connections[connection.id]
                 break
-            message = AccessClientToRelayMessage.model_validate_json(json_data)
+            if raw["type"] == "websocket.disconnect":
+                logger.info("access client disconnected: %s", connection.id)
+                if connection.id in self.active_relayed_connections:
+                    del self.active_relayed_connections[connection.id]
+                break
+            binary = raw.get("bytes")
+            if binary is not None:
+                # One connection per access-client websocket, so the raw bytes
+                # are this connection's payload (no connection_id needed).
+                await connection.send(binary)
+                continue
+            message = AccessClientToRelayMessage.model_validate_json(raw["text"])
             if isinstance(message.inner, AtRTCPDataMessage):
                 logger.debug(
                     "Received TCP data message from access client: %s", message
@@ -628,20 +701,24 @@ class NetworkRelay:
         self,
         access_client_connection: WebSocket,
         relayed_connection: TcpConnectionAsync,
+        access_client_supports_binary: bool = False,
     ):
         while relayed_connection.id in self.active_relayed_connections:
             try:
-                data = await relayed_connection.read(1024)
+                data = await relayed_connection.read(READ_CHUNK_SIZE)
                 if not data:
                     break
-                await access_client_connection.send_text(
-                    RelayToAccessClientMessage(
-                        inner=RtATCPDataMessage(
-                            connection_id=relayed_connection.id,
-                            data_base64=base64.b64encode(data).decode("utf-8"),
-                        )
-                    ).model_dump_json()
-                )
+                if access_client_supports_binary:
+                    await access_client_connection.send_bytes(data)
+                else:
+                    await access_client_connection.send_text(
+                        RelayToAccessClientMessage(
+                            inner=RtATCPDataMessage(
+                                connection_id=relayed_connection.id,
+                                data_base64=base64.b64encode(data).decode("utf-8"),
+                            )
+                        ).model_dump_json()
+                    )
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -676,6 +753,7 @@ class NetworkRelay:
         )
         if edge_agent_connection_id in self.registered_agent_connections:
             del self.registered_agent_connections[edge_agent_connection_id]
+        self.agent_connection_id_to_supports_binary.pop(edge_agent_connection_id, None)
         if agent_connection:
             # remove from agent_connections list
             try:

--- a/http_network_relay/network_relay.py
+++ b/http_network_relay/network_relay.py
@@ -646,7 +646,8 @@ class NetworkRelay:
             await access_client_connection.send_text(
                 RelayToAccessClientMessage(
                     inner=RtAStartOKMessage(
-                        connection_id=connection.id, supports_binary=True
+                        connection_id=connection.id,
+                        supports_binary=connection.agent_supports_binary,
                     )
                 ).model_dump_json()
             )

--- a/http_network_relay/network_relay.py
+++ b/http_network_relay/network_relay.py
@@ -234,7 +234,15 @@ class NetworkRelay:
         ] = {}  # connection_id -> WebSocket for access clients
         # agent_connection_id -> whether that agent negotiated binary framing
         self.agent_connection_id_to_supports_binary: dict[str, bool] = {}
+        self.agent_connection_locks: dict[WebSocket, asyncio.Lock] = {}
         self.loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def _agent_send_lock(self, agent_connection: WebSocket) -> asyncio.Lock:
+        lock = self.agent_connection_locks.get(agent_connection)
+        if lock is None:
+            lock = asyncio.Lock()
+            self.agent_connection_locks[agent_connection] = lock
+        return lock
 
     async def accept_ws_and_start_msg_loop_for_edge_agents(
         self, edge_agent_connection: WebSocket
@@ -292,11 +300,12 @@ class NetworkRelay:
                 if edge_agent_connection.application_state != WebSocketState.CONNECTED:
                     break
                 try:
-                    await edge_agent_connection.send_text(
-                        RelayToEdgeAgentMessage(
-                            inner=RtEKeepAliveMessage()
-                        ).model_dump_json()
-                    )
+                    async with self._agent_send_lock(edge_agent_connection):
+                        await edge_agent_connection.send_text(
+                            RelayToEdgeAgentMessage(
+                                inner=RtEKeepAliveMessage()
+                            ).model_dump_json()
+                        )
                 except RuntimeError as e:
                     # if the connection is closed, it's fine
                     if not self.is_closed_error(e):
@@ -509,9 +518,10 @@ class NetworkRelay:
     ):
         response_queue = asyncio.Queue(maxsize=1)
         self.initiate_connection_answer_queues[message.connection_id] = response_queue
-        await agent_connection.send_text(
-            RelayToEdgeAgentMessage(inner=message).model_dump_json()
-        )
+        async with self._agent_send_lock(agent_connection):
+            await agent_connection.send_text(
+                RelayToEdgeAgentMessage(inner=message).model_dump_json()
+            )
         logger.debug(
             "Waiting for response for connection_id: %s",
             message.connection_id,
@@ -524,16 +534,18 @@ class NetworkRelay:
     async def send_connection_message(
         self, agent_connection: WebSocket, message: RtETCPDataMessage
     ):
-        await agent_connection.send_text(
-            RelayToEdgeAgentMessage(inner=message).model_dump_json()
-        )
+        async with self._agent_send_lock(agent_connection):
+            await agent_connection.send_text(
+                RelayToEdgeAgentMessage(inner=message).model_dump_json()
+            )
 
     async def send_connection_binary(
         self, agent_connection: WebSocket, connection_id: str, payload: bytes
     ):
-        await agent_connection.send_bytes(
-            encode_tcp_binary_frame(connection_id, payload)
-        )
+        async with self._agent_send_lock(agent_connection):
+            await agent_connection.send_bytes(
+                encode_tcp_binary_frame(connection_id, payload)
+            )
 
     def is_closed_error(self, error: RuntimeError):
         str_e = error.args[0]
@@ -547,14 +559,15 @@ class NetworkRelay:
     ):
         # inform agent
         try:
-            await agent_connection.send_text(
-                RelayToEdgeAgentMessage(
-                    inner=RtEConnectionCloseMessage(
-                        message="Connection closed by relay",
-                        connection_id=connection_id,
-                    )
-                ).model_dump_json()
-            )
+            async with self._agent_send_lock(agent_connection):
+                await agent_connection.send_text(
+                    RelayToEdgeAgentMessage(
+                        inner=RtEConnectionCloseMessage(
+                            message="Connection closed by relay",
+                            connection_id=connection_id,
+                        )
+                    ).model_dump_json()
+                )
 
         except RuntimeError as e:
             # if the connection is closed, it's fine
@@ -765,3 +778,4 @@ class NetworkRelay:
             for connection_id, connection in active_relayed_connections.items():
                 if connection.agent_connection == agent_connection:
                     await self.close_relayed_connection(connection_id, agent_connection)
+            self.agent_connection_locks.pop(agent_connection, None)

--- a/http_network_relay/pydantic_models.py
+++ b/http_network_relay/pydantic_models.py
@@ -2,10 +2,12 @@ from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-# Maximum bytes read from a socket/stdin per relayed message. Larger chunks mean
-# fewer WebSocket frames and less per-message JSON/base64 overhead for bulk
-# transfers (e.g. nix store closures during deploy).
-READ_CHUNK_SIZE = 1024 * 1024
+# Maximum bytes read per relayed message. The access-client leg is pipe-bound
+# (Linux pipes default to 64 KiB) and SSH frames in ~32-35 KiB packets. Kept
+# modestly above that ceiling for the non-pipe-bound local TCP leg, while
+# avoiding extra buffer memory and WebSocket head-of-line blocking on
+# memory-constrained SBCs.
+READ_CHUNK_SIZE = 128 * 1024
 
 
 def encode_tcp_binary_frame(connection_id: str, payload: bytes) -> bytes:

--- a/http_network_relay/pydantic_models.py
+++ b/http_network_relay/pydantic_models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 # Maximum bytes read from a socket/stdin per relayed message. Larger chunks mean
 # fewer WebSocket frames and less per-message JSON/base64 overhead for bulk
 # transfers (e.g. nix store closures during deploy).
-READ_CHUNK_SIZE = 65536
+READ_CHUNK_SIZE = 1024 * 1024
 
 
 def encode_tcp_binary_frame(connection_id: str, payload: bytes) -> bytes:

--- a/http_network_relay/pydantic_models.py
+++ b/http_network_relay/pydantic_models.py
@@ -1,6 +1,26 @@
+import uuid
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
+
+# Maximum bytes read from a socket/stdin per relayed message. Larger chunks mean
+# fewer WebSocket frames and less per-message JSON/base64 overhead for bulk
+# transfers (e.g. nix store closures during deploy).
+READ_CHUNK_SIZE = 65536
+
+
+def encode_tcp_binary_frame(connection_id: str, payload: bytes) -> bytes:
+    """Frame raw TCP payload for the relay<->agent channel as a binary WebSocket
+    message: the 16-byte connection UUID followed by the raw bytes.
+    The connection UUID prefix is required because many connections are
+    multiplexed over the agent's single WebSocket.
+    """
+    return uuid.UUID(connection_id).bytes + payload
+
+
+def decode_tcp_binary_frame(frame: bytes) -> tuple[str, bytes]:
+    """Inverse of encode_tcp_binary_frame: returns (connection_id, payload)."""
+    return str(uuid.UUID(bytes=bytes(frame[:16]))), bytes(frame[16:])
 
 
 class EdgeAgentToRelayMessage(BaseModel):
@@ -20,6 +40,7 @@ class EtRStartMessage(BaseModel):
     )
     kind: Literal["start"] = "start"
     last_error: Optional[str] = None
+    supports_binary: bool = False
 
 
 class EtRInitiateConnectionErrorMessage(BaseModel):
@@ -67,6 +88,7 @@ class RtEInitiateConnectionMessage(BaseModel):
     target_port: int
     protocol: str
     connection_id: str
+    supports_binary: bool = False
 
 
 class RtETCPDataMessage(BaseModel):

--- a/http_network_relay/pydantic_models.py
+++ b/http_network_relay/pydantic_models.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -15,12 +14,18 @@ def encode_tcp_binary_frame(connection_id: str, payload: bytes) -> bytes:
     The connection UUID prefix is required because many connections are
     multiplexed over the agent's single WebSocket.
     """
-    return uuid.UUID(connection_id).bytes + payload
+    return bytes.fromhex(connection_id.replace("-", "")) + payload
 
 
 def decode_tcp_binary_frame(frame: bytes) -> tuple[str, bytes]:
     """Inverse of encode_tcp_binary_frame: returns (connection_id, payload)."""
-    return str(uuid.UUID(bytes=bytes(frame[:16]))), bytes(frame[16:])
+    if len(frame) < 16:
+        raise ValueError(
+            f"frame too short to contain a connection id: {len(frame)} bytes"
+        )
+    h = bytes(frame[:16]).hex()
+    connection_id = f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+    return connection_id, bytes(frame[16:])
 
 
 class EdgeAgentToRelayMessage(BaseModel):

--- a/http_network_relay/tests/test_run_all.py
+++ b/http_network_relay/tests/test_run_all.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import socket
 import subprocess
@@ -141,3 +142,177 @@ def test_can_run_and_proxy_tcp():
     access_client.wait()
 
     assert response == b"olleh\n"
+
+
+def test_binary_frame_roundtrip():
+    import uuid as _uuid
+
+    from http_network_relay.access_client import AtRStartMessage, RtAStartOKMessage
+    from http_network_relay.pydantic_models import (
+        EtRStartMessage,
+        RtEInitiateConnectionMessage,
+        decode_tcp_binary_frame,
+        encode_tcp_binary_frame,
+    )
+
+    cid = str(_uuid.uuid4())
+    payload = random.randbytes(1000)
+    frame = encode_tcp_binary_frame(cid, payload)
+    assert len(frame) == 16 + len(payload)
+    out_cid, out_payload = decode_tcp_binary_frame(frame)
+    assert out_cid == cid
+    assert out_payload == payload
+
+    # Backward compatibility: a message from an older peer omits supports_binary,
+    # which must default to False so the new side falls back to JSON framing.
+    assert EtRStartMessage().supports_binary is False
+    assert (
+        RtEInitiateConnectionMessage(
+            target_ip="x", target_port=1, protocol="tcp", connection_id=cid
+        ).supports_binary
+        is False
+    )
+    assert (
+        AtRStartMessage(
+            connection_target="a",
+            target_ip="x",
+            target_port=1,
+            protocol="tcp",
+            secret="s",
+        ).supports_binary
+        is False
+    )
+    assert RtAStartOKMessage().supports_binary is False
+
+
+@pytest.mark.timeout(30)
+def test_large_binary_payload_roundtrip():
+    # Push several MB through the relay to exercise the 64 KiB binary-framing
+    # data path and assert byte-for-byte integrity (the nix-copy deploy case).
+    agent_secret = random.randbytes(16).hex()
+    relay_secret = random.randbytes(16).hex()
+    agent_name = "test_agent"
+    port_listener = random.randint(10000, 20000)
+    port_relay = random.randint(20000, 30000)
+    payload = random.randbytes(3 * 1024 * 1024)
+
+    started = []
+
+    def echo_server():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", port_listener))
+        s.listen(1)
+        conn, _ = s.accept()
+        try:
+            while True:
+                data = conn.recv(65536)
+                if not data:
+                    break
+                conn.sendall(data)
+        except OSError:
+            pass
+        finally:
+            conn.close()
+            s.close()
+
+    credf = tempfile.NamedTemporaryFile(delete=False)
+    credf.write(
+        json.dumps(
+            {
+                "edge-agents": {agent_name: agent_secret},
+                "access-client-secrets": [relay_secret],
+            }
+        ).encode()
+    )
+    credf.flush()
+    credf.close()
+
+    echo_thread = threading.Thread(target=echo_server, daemon=True)
+    echo_thread.start()
+    time.sleep(0.2)
+
+    relay = subprocess.Popen(
+        [
+            "python",
+            "-m",
+            "http_network_relay.network_relay_example",
+            "--port",
+            str(port_relay),
+            "--credentials-file",
+            credf.name,
+        ]
+    )
+    started.append(relay)
+    time.sleep(0.8)
+
+    agent = subprocess.Popen(
+        [
+            "python",
+            "-m",
+            "http_network_relay.edge_agent_example",
+            "--secret",
+            agent_secret,
+            "--relay-url",
+            f"ws://127.0.0.1:{port_relay}/ws_for_edge_agents",
+            "--name",
+            agent_name,
+        ]
+    )
+    started.append(agent)
+    time.sleep(0.8)
+
+    access_client = subprocess.Popen(
+        [
+            "python",
+            "-m",
+            "http_network_relay.access_client_example",
+            "--secret",
+            relay_secret,
+            agent_name,
+            "127.0.0.1",
+            str(port_listener),
+            "tcp",
+            "--relay-url",
+            f"ws://127.0.0.1:{port_relay}/ws_for_access_clients",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    started.append(access_client)
+
+    def feed():
+        try:
+            access_client.stdin.write(payload)
+            access_client.stdin.flush()
+        except (BrokenPipeError, ValueError):
+            pass
+
+    threading.Thread(target=feed, daemon=True).start()
+
+    received = bytearray()
+    result = {"err": None}
+
+    def drain():
+        try:
+            while len(received) < len(payload):
+                chunk = access_client.stdout.read1(65536)
+                if not chunk:
+                    break
+                received.extend(chunk)
+        except Exception as e:  # pragma: no cover
+            result["err"] = e
+
+    drainer = threading.Thread(target=drain, daemon=True)
+    drainer.start()
+    drainer.join(timeout=20)
+
+    for p in started:
+        p.terminate()
+        time.sleep(0.1)
+        p.kill()
+    os.unlink(credf.name)
+
+    assert result["err"] is None, result["err"]
+    assert len(received) == len(payload), f"got {len(received)} of {len(payload)} bytes"
+    assert bytes(received) == payload

--- a/http_network_relay/tests/test_run_all.py
+++ b/http_network_relay/tests/test_run_all.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import random
@@ -6,8 +7,19 @@ import subprocess
 import tempfile
 import threading
 import time
+import uuid as _uuid
 
 import pytest
+
+from http_network_relay.access_client import AtRStartMessage, RtAStartOKMessage
+from http_network_relay.network_relay import NetworkRelay
+from http_network_relay.pydantic_models import (
+    EtRStartMessage,
+    RtEInitiateConnectionMessage,
+    RtETCPDataMessage,
+    decode_tcp_binary_frame,
+    encode_tcp_binary_frame,
+)
 
 
 @pytest.mark.timeout(3)
@@ -145,16 +157,6 @@ def test_can_run_and_proxy_tcp():
 
 
 def test_binary_frame_roundtrip():
-    import uuid as _uuid
-
-    from http_network_relay.access_client import AtRStartMessage, RtAStartOKMessage
-    from http_network_relay.pydantic_models import (
-        EtRStartMessage,
-        RtEInitiateConnectionMessage,
-        decode_tcp_binary_frame,
-        encode_tcp_binary_frame,
-    )
-
     cid = str(_uuid.uuid4())
     payload = random.randbytes(1000)
     frame = encode_tcp_binary_frame(cid, payload)
@@ -316,3 +318,54 @@ def test_large_binary_payload_roundtrip():
     assert result["err"] is None, result["err"]
     assert len(received) == len(payload), f"got {len(received)} of {len(payload)} bytes"
     assert bytes(received) == payload
+
+
+@pytest.mark.timeout(5)
+def test_concurrent_agent_sends_are_serialized():
+    # Multiple relayed connections + keep_alive share one agent WebSocket.
+    # uvicorn's legacy websocket protocol asserts only one send/drain is ever
+    # in flight; an unsynchronized second writer crashes the connection.
+    # NetworkRelay must serialize writes per agent connection with a lock.
+
+    class FakeAgentWebSocket:
+        def __init__(self):
+            self.busy = False
+            self.max_concurrent = 0
+            self.concurrent = 0
+
+        async def send_text(self, data):
+            await self._send()
+
+        async def send_bytes(self, data):
+            await self._send()
+
+        async def _send(self):
+            self.concurrent += 1
+            self.max_concurrent = max(self.max_concurrent, self.concurrent)
+            assert not self.busy, "concurrent send on one agent connection"
+            self.busy = True
+            await asyncio.sleep(0.05)  # simulate a slow drain() on a big frame
+            self.busy = False
+            self.concurrent -= 1
+
+    async def run():
+        relay = NetworkRelay()
+        ws = FakeAgentWebSocket()
+        await asyncio.gather(
+            relay.send_connection_binary(
+                ws, str(random.randbytes(16).hex()), b"x" * 100
+            ),
+            relay.send_connection_message(
+                ws, RtETCPDataMessage(connection_id="c1", data_base64="")
+            ),
+            relay.send_connection_binary(
+                ws, str(random.randbytes(16).hex()), b"y" * 100
+            ),
+            relay.send_connection_message(
+                ws, RtETCPDataMessage(connection_id="c2", data_base64="")
+            ),
+        )
+        return ws.max_concurrent
+
+    max_concurrent = asyncio.run(run())
+    assert max_concurrent == 1


### PR DESCRIPTION
## Problem
nix-copy closure transfers through the relay (controller <-ws-> edge_agent on
device) were CPU-bound, not network-bound. Reported by a user: deploys stay
slow even when the device is on the same LAN as the controller, ruling out a
bandwidth/network explanation.

Two compounding causes, both fixed here:

1. The relay previously shipped every TCP chunk as base64-encoded JSON
   (`AtRTCPDataMessage`/`EtRTCPDataMessage`), costing ~33% size overhead plus
   per-chunk JSON/pydantic (de)serialization. Now framed as raw binary
   websocket messages (`encode_tcp_binary_frame`/`decode_tcp_binary_frame`,
   16-byte connection-id prefix), negotiated via `supports_binary` with a
   fallback to the old base64 path for older peers.
2. `websockets.connect()` defaults to `compression="deflate"`, and uvicorn
   defaults `ws_per_message_deflate=True`. Every 64 KiB frame of already-dense
   NAR/binary nix-store data was being DEFLATE-compressed and decompressed on
   both websocket legs, on a single-threaded asyncio event loop — expensive
   even on capable hardware, and a severe bottleneck on weak-CPU edge devices
   (e.g. Raspberry Pi) running the edge agent. Compression is now explicitly
   disabled (`compression=None` client-side, `ws_per_message_deflate=False`
   for the bundled example server) since the payloads gain effectively
   nothing from DEFLATE.

## Testing
`pytest http_network_relay/tests/test_run_all.py` — 3 passed, including a
3 MiB random-byte round trip through the full access-client -> relay ->
edge-agent -> TCP echo path.